### PR TITLE
Various cleanup to allow Drush Make to run from the web container.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+docker/settings.local.php
 web/
 docker-compose.override.yml
 drupal.make

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,11 +9,13 @@ web:
     - './docker/drupal-cron.conf:/etc/cron.d/drupal-cron.conf:ro'
     - './docker/prepare-environment.sh:/etc/my_init.d/prepare-environment.sh'
     - './docker/php.ini:/etc/php/5.6/mods-available/ding.ini'
+    - "${SSH_AUTH_SOCK}:/tmp/ssh-agent"
   links:
     - db
     - memcached
   environment:
     PHP_EXTRA_EXTENSIONS: msgpack igbinary memcached
+    SSH_AUTH_SOCK: /tmp/ssh-agent
   working_dir: /var/www/html
 db:
   image: mariadb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ web:
     - '443/tcp'
   volumes:
     - './web:/var/www/html'
+    - './drupal.make:/var/www/html/drupal.make'
     - './docker/settings.php:/var/www/html/sites/default/settings.php:ro'
     - './docker/settings.local.php:/var/www/html/sites/default/settings.local.php:ro'
     - './docker/drupal-cron.conf:/etc/cron.d/drupal-cron.conf:ro'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ web:
   volumes:
     - './web:/var/www/html'
     - './docker/settings.php:/var/www/html/sites/default/settings.php:ro'
+    - './docker/settings.local.php:/var/www/html/sites/default/settings.local.php:ro'
     - './docker/drupal-cron.conf:/etc/cron.d/drupal-cron.conf:ro'
     - './docker/prepare-environment.sh:/etc/my_init.d/prepare-environment.sh'
     - './docker/php.ini:/etc/php/5.6/mods-available/ding.ini'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,16 +30,9 @@ db:
     MYSQL_PASSWORD: ichai4IesaeSainohV0oT2ca9hooNi
 gulp:
   image: node:argon
-  volumes_from:
-    - web
-  entrypoint: "/bin/sh -c 'cd /var/www/html/profiles/ding2/themes/ddbasic && npm install --unsafe-perm && node_modules/.bin/gulp watch'"
-drush:
-  image: drush/drush
-  links:
-    - db
-  volumes_from:
-    - web
-  working_dir: /var/www/html
+  volumes:
+    - './web/profiles/ding2/themes/ddbasic:/src'
+  entrypoint: "/bin/sh -c 'cd /src && npm install --unsafe-perm && node_modules/.bin/gulp sass'"
 memcached:
   image: memcached
 varnish:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ web:
     - db
     - memcached
   environment:
-    PHP_EXTRA_EXTENSIONS: memcached
+    PHP_EXTRA_EXTENSIONS: msgpack igbinary memcached
   working_dir: /var/www/html
 db:
   image: mariadb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,13 +29,6 @@ gulp:
   volumes:
     - './web/profiles/ding2/themes/ddbasic:/src'
   entrypoint: "/bin/sh -c 'cd /src && npm install --unsafe-perm && node_modules/.bin/gulp sass'"
-drush:
-  image: drush/drush
-  links:
-    - db
-  volumes_from:
-    - web
-  working_dir: /var/www/html
 memcached:
   image: memcached
 varnish:

--- a/docker/prepare-environment.sh
+++ b/docker/prepare-environment.sh
@@ -19,3 +19,5 @@ fi
 
 # Enable ding PHP configuration.
 phpenmod ding
+
+mkdir -p /root/.ssh && touch /root/.ssh/known_hosts && ssh-keyscan -H github.com >> /root/.ssh/known_hosts && chmod 600 /root/.ssh/known_hosts

--- a/docker/prepare-environment.sh
+++ b/docker/prepare-environment.sh
@@ -1,8 +1,11 @@
 #!/bin/sh
 
 # Install git and patch commands, since we need them for Drush Make operations.
-apt-get update && \
-DEBIAN_FRONTEND=noninteractive apt-get -y install git patch
+DPKG_STATUS=$(dpkg-query -s git 2>/dev/null)
+if [ $? -eq 1 ]; then
+  apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y install git patch
+fi
 
 # Make sure files folders exists and are owned by www-data.
 mkdir -p /var/www/html/sites/default/files/private

--- a/docker/prepare-environment.sh
+++ b/docker/prepare-environment.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+# Install git and patch commands, since we need them for Drush Make operations.
 apt-get update && \
 DEBIAN_FRONTEND=noninteractive apt-get -y install git patch
 

--- a/docker/prepare-environment.sh
+++ b/docker/prepare-environment.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+apt-get update && \
+DEBIAN_FRONTEND=noninteractive apt-get -y install git patch
+
 # Make sure files folders exists and are owned by www-data.
 mkdir -p /var/www/html/sites/default/files/private
 chown -R www-data /var/www/html/sites/default/files

--- a/docker/settings.php
+++ b/docker/settings.php
@@ -18,6 +18,11 @@ $conf['block_cache'] = 1;
 $conf['preprocess_css'] = 1;
 $conf['preprocess_js'] = 1;
 
+
+if (file_exists(__DIR__ . '/settings.local.php')) {
+  include __DIR__ . '/settings.local.php';
+}
+
 // // Ensures that form data is not moved out of the database. It's important to
 // // keep this in non-volatile memory (e.g. the database).
 // $conf['cache_class_cache_form'] = 'DrupalDatabaseCache';


### PR DESCRIPTION
This will allow Drush Make to run from within the web container, and changes the flow like so:
```
curl -LOSs https://raw.github.com/ding2/ding2/master/drupal.make
docker-compose up -d
# Wait a minute or so for the containers to initialize and update.
mkdir -p web
docker-compose exec web drush make --concurrency=4 --overwrite --shallow-clone --contrib-destination=profiles/ding2/ drupal.make .
# You can now run site-install if required:
docker-compose exec web drush site-install --site-name="Ballerup Bibliotek (TEST)" ding2
```