### PR TITLE
Get gulp actually running.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,9 +26,9 @@ db:
     MYSQL_PASSWORD: ichai4IesaeSainohV0oT2ca9hooNi
 gulp:
   image: node:argon
-  volumes:
-    - './web/profiles/ding2/themes/ddbasic:/src'
-  entrypoint: "/bin/sh -c 'cd /src && npm install --unsafe-perm && node_modules/.bin/gulp sass'"
+  volumes_from:
+    - web
+  entrypoint: "/bin/sh -c 'cd /var/www/html/profiles/ding2/themes/ddbasic && npm install --unsafe-perm && node_modules/.bin/gulp watch'"
 drush:
   image: drush/drush
   links:


### PR DESCRIPTION
Gulp couldn’t access zen library since it was out of container root