### PR TITLE
Add documentation for how to work with a non-default codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,36 @@ Get a ding make file
 
 Build the site with drush make:
 ```sh
-% drush make --contrib-destination=profiles/ding2/ drupal.make web
+% drush make --contrib-destination=profiles/ding2/ drupal.make web --working-copy
 ```
 
 Then you can start the Docker containers:
 ```sh
 % docker-compose up
 ```
+
+### Using a custom version of the codebase
+
+To use a custom version of the code base then first complete the steps above. add your fork as a remote to the profile and checkout your branch:
+
+```sh
+% cd web/profiles/ding2
+% git remote add [remote name] [remote repository url]
+% git fetch [remote name]
+% git checkout -t [remote name]/[remote branch]
+```
+
+In the following example we work with the `master` branch from the Reload fork of Ding2:
+
+```sh
+% cd web/profiles/ding2
+% git remote add reload git@github.com:reload/ding2.git
+% git fetch reload
+% git checkout -t reload/master
+```
+
+
+Note that you may have to clear the cache, download new dependencies or even reinstall the site to make the changes take effect.
 
 ## Install ding
 


### PR DESCRIPTION
Add `--working-copy` option to drush make to download projects with
version control. This is necessary if you as a developer want to work
with the code. It is also a prerequisite for switching to another
branch og repository.

Add instructions for checking out a branch in a fork of the original
repository.