### PR TITLE
Use correct tag for php container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - php:fpm
 
   php:
-    image: reload/drupal-php7-fpm:php5-experimental
+    image: reload/drupal-php7-fpm:5.6
     ports:
       - '9000'
     environment:


### PR DESCRIPTION
If the PHP image is removed and rebuild, the site is dead because it uses PHP 7.