### PR TITLE
Add default XDebug setup for Docker for Mac

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -5,6 +5,9 @@ services:
       - 'bbs-webroot-sync:/var/www/web:nocopy'
       - 'bbs-vendor-sync:/var/www/vendor:nocopy'
       - './docker/docker.settings.php:/var/www/web/sites/default/settings.php:delegated'
+  php:
+    environment:
+      XDEBUG_CONFIG: "remote_connect_back=0 remote_host=docker.for.mac.localhost"
 
 volumes:
   bbs-webroot-sync:


### PR DESCRIPTION
Docker sync is primarily used by Docker for Mac users where nfs is
slow. Thus we can safely hardcode the remote host accordingly.